### PR TITLE
Fix all warnings given by GCC

### DIFF
--- a/include/sai.hpp
+++ b/include/sai.hpp
@@ -133,13 +133,12 @@ public:
 private:
 	std::ifstream FileIn;
 
-	std::uint32_t PageCount;
-
 	VirtualPage Buffer;
-	std::uint32_t CurrentPage;
 
-	// Decryption Key
-	const std::uint32_t* Key;
+    // Decryption Key
+    const std::uint32_t* Key;
+
+    std::uint32_t CurrentPage;
 
 	// Caching
 
@@ -150,6 +149,8 @@ private:
 
 	std::unique_ptr<VirtualPage> TableCache;
 	std::uint32_t TableCacheIndex;
+
+    std::uint32_t PageCount;
 };
 
 class ifstream : public std::istream
@@ -196,11 +197,11 @@ public:
 
 	// Return false to stop iteration
 
-	virtual bool VisitFolderBegin(VirtualFileEntry& Entry);;
+    virtual bool VisitFolderBegin(VirtualFileEntry&);
 
-	virtual bool VisitFolderEnd(VirtualFileEntry& Entry);;
+    virtual bool VisitFolderEnd(VirtualFileEntry&);
 
-	virtual bool VisitFile(VirtualFileEntry& Entry);;
+    virtual bool VisitFile(VirtualFileEntry&);
 };
 
 class VirtualFileSystem

--- a/samples/Tree.cpp
+++ b/samples/Tree.cpp
@@ -25,7 +25,7 @@ public:
 		++FolderDepth;
 		return true;
 	}
-	bool VisitFolderEnd(sai::VirtualFileEntry& Entry) override
+    bool VisitFolderEnd(sai::VirtualFileEntry& /*Entry*/) override
 	{
 		--FolderDepth;
 		return true;

--- a/source/sai.cpp
+++ b/source/sai.cpp
@@ -351,7 +351,7 @@ std::streambuf::int_type ifstreambuf::underflow()
 std::streambuf::pos_type ifstreambuf::seekoff(
 	std::streambuf::off_type Offset,
 	std::ios_base::seekdir Direction,
-	std::ios_base::openmode Mode
+    std::ios_base::openmode /*Mode*/
 )
 {
 	std::streambuf::pos_type Position;
@@ -593,17 +593,17 @@ VirtualFileVisitor::~VirtualFileVisitor()
 {
 }
 
-bool VirtualFileVisitor::VisitFolderBegin(VirtualFileEntry& Entry)
+bool VirtualFileVisitor::VisitFolderBegin(VirtualFileEntry& /*Entry*/)
 {
 	return true;
 }
 
-bool VirtualFileVisitor::VisitFolderEnd(VirtualFileEntry& Entry)
+bool VirtualFileVisitor::VisitFolderEnd(VirtualFileEntry& /*Entry*/)
 {
 	return true;
 }
 
-bool VirtualFileVisitor::VisitFile(VirtualFileEntry& Entry)
+bool VirtualFileVisitor::VisitFile(VirtualFileEntry& /*Entry*/)
 {
 	return true;
 }
@@ -643,7 +643,7 @@ std::unique_ptr<VirtualFileEntry> VirtualFileSystem::GetEntry(const char* Path)
 	);
 
 	std::string CurPath(Path);
-	constexpr char* PathDelim = "./";
+    const char* PathDelim = "./";
 
 	const char* CurToken = std::strtok(&CurPath[0], PathDelim);
 
@@ -879,7 +879,7 @@ std::tuple<
 		Thumbnail->Read(Header.Height);
 		Thumbnail->Read(Header.Magic);
 
-		if( Header.Magic != '23MB' )
+        if( Header.Magic != *(uint*)"23MB" )
 		{
 			return std::make_tuple(nullptr, 0, 0);
 		}


### PR DESCRIPTION
Hi,

We're investigating if we can integrate this library to be used by [Krita](https://krita.org/en/). When building it, there were a couple of compilation warnings, most of which order of initialization and unused variable errors.

In one case an error because of constexpr char array, which I tried to fix by making it a regular const char array, some research seemed to suggest constexpr is only used in very specific circumstances.

The other was a multicharacter constant warning, because you're trying to compare a uint to char. I tried using a conversion there, but I am not yet familiar enough with the code structure if this was the correct way to go about it.

Anyhow, these are my attempts at fixing these warnings so your library isn't so noisy when compiling.