### PR TITLE
fix: `VirtualFileEntry::Read` now works with `big` pages.

### DIFF
--- a/samples/Document.cpp
+++ b/samples/Document.cpp
@@ -117,7 +117,7 @@ void ProcessLayerFile(
 		LayerFile.Read<std::uint32_t>(CurTagSize);
 		switch( CurTag )
 		{
-			case sai::Tag("name"):
+			case sai::Tag("name", sai::Endian::Big):
 			{
 				char LayerName[256] = {};
 				LayerFile.Read(LayerName, 256);


### PR DESCRIPTION
Fixes #6.

First of all, thanks for the amazing for the work you did reverse engineering the sai file format. I fixed this a while back on a rewrite of the library that I did on Rust, but completely forgot to actually fix it here. TBH, if you ask me why _your_ implementation was wrong, then IDK; I came out with this as the "most logical solution" that would solve the problem and after a couple hours of debugging I was able to make it work. I left a `TODO` and a `FIXME` in here so that you can decide what you want to do with those suggestions.