### PR TITLE
fix: `BlendingModes` tags are big endian.

### DIFF
--- a/include/sai.hpp
+++ b/include/sai.hpp
@@ -49,15 +49,15 @@ enum class LayerType
 
 enum class BlendingModes : std::uint32_t
 {
-	PassThrough = Tag("pass"),
-	Normal      = Tag("norm"),
-	Multiply    = Tag("mul "),
-	Screen      = Tag("scrn"),
-	Overlay     = Tag("over"),
-	Luminosity  = Tag("add "),
-	Shade       = Tag("sub "),
-	LumiShade   = Tag("adsb"),
-	Binary      = Tag("cbin")
+	PassThrough = Tag<std::endian::big>("pass"),
+	Normal      = Tag<std::endian::big>("norm"),
+	Multiply    = Tag<std::endian::big>("mul "),
+	Screen      = Tag<std::endian::big>("scrn"),
+	Overlay     = Tag<std::endian::big>("over"),
+	Luminosity  = Tag<std::endian::big>("add "),
+	Shade       = Tag<std::endian::big>("sub "),
+	LumiShade   = Tag<std::endian::big>("adsb"),
+	Binary      = Tag<std::endian::big>("cbin")
 };
 
 #pragma pack(push, 1)


### PR DESCRIPTION
After the comment yesterday asking if `Big` endian should be the default, I needed to verify it, because I was certain that I was reading `BlendingModes` on my library with big endian. And it is indeed big endian.

To verify it, I modified `Document.cpp` to also print the `Blending` field after the layer identifier:
```cpp
std::printf("\t\tBlending: %d\n", LayerHeader.Blending);
```

And this was the output with a simple single layer sai file ( has blending mode of Normal ):
```
./Document samples/blending-normal.sai
Width: 25 Height: 25
        - "0000000a"
                Blending: 1852797549
                Name: Bg
Iterated Document of samples/blending-normal.sai in 3108778 ns
```

If I check the value of `BlendingModes::Normal` it gives `1836216174`, but if I change its endian to `Big`, it shows `1852797549`, which matches with the output of Document.