### PR TITLE
Make sai library shared library, add install directives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,11 @@ set( CMAKE_COLOR_MAKEFILE ON )
 set( CMAKE_VERBOSE_MAKEFILE ON )
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
+option( BUILD_SHARED_LIBS "Build using shared libraries" OFF )
+
+# This provides standard installation directory variables.
+include(GNUInstallDirs)
+
 # Determine if we're built as a subproject (using add_subdirectory)
 # or if this is the master project.
 set( MASTER_PROJECT OFF )
@@ -76,7 +81,7 @@ endif()
 
 ### libsai
 add_library(
-	sai SHARED
+	sai
 	source/document.cpp
 	source/ifstream.cpp
 	source/ifstreambuf.cpp
@@ -144,18 +149,13 @@ if( MASTER_PROJECT )
 	)
 
 	install(
-		TARGETS Thumbnail Decrypt Tree Document
-		DESTINATION bin/
-	)
-
-	install(
 		TARGETS sai
-		DESTINATION lib/
+		DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	)
 
 	install(
 		FILES include/sai.hpp
-		DESTINATION include/
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 	)
 
 endif()


### PR DESCRIPTION
Hi,

Thanks for providing this library!

I'm working on adding libsai support to my application, and for that needed to adjust the install process to also build a shared library and to install the files into the respective locations. This adds to CMakeLists.txt the `SHARED` keyword to the `add_library` command and provides `install` directives for the executables, the header file, and the library itself.