### PR TITLE
Fix install directive to also install sai2.hpp and util.hpp, install into libsai subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,9 @@ if( MASTER_PROJECT )
 
 	install(
 		FILES include/sai.hpp
-		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+			  include/sai2.hpp
+			  include/util.hpp
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libsai
 	)
 
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if( MASTER_PROJECT )
 		FILES include/sai.hpp
 			  include/sai2.hpp
 			  include/util.hpp
-		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libsai
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/sai
 	)
 
 endif()


### PR DESCRIPTION
The current install directive in CMakeLists.txt omits the sai2.hpp and util.hpp header files.

Also, I added another change in this pull request, where the three header files are put into a `libsai` subfolder (e.g., `/usr/include/libsai`). This is mostly due to the `util.hpp` header file, as it has a rather generic name and is currently placed in the same folder as many other headers, making a conflict between two `util.hpp` files nonzero (albeit still small). What do you think about this change?